### PR TITLE
modify: the way to take latest ruby version

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -70,8 +70,9 @@ brew install rbenv
 brew install ruby-build
 rbenv --version
 rbenv install -l
-rbenv install 2.4.0
-rbenv global 2.4.0
+ruby_latest=$(rbenv install -l | grep -v '[a-z]' | tail -1 | sed 's/ //g')
+rbenv install $ruby_latest
+rbenv global $ruby_latest
 rbenv rehash
 ruby -v
 echo " ------------ END ------------"


### PR DESCRIPTION
I modified ruby integration block.

details: _2016_(specific version) -> _$latest_version_(latest ruby version number variable)
using following...

$(rbenv install -l | grep -v '[a-z]' | tail -1 | sed 's/ //g')