### PR TITLE
:sparkles: Update app install script

### DIFF
--- a/app.sh
+++ b/app.sh
@@ -23,7 +23,6 @@ brew install --cask iterm2
 brew install --cask sourcetree
 brew install --cask vlc
 brew install --cask google-japanese-ime
-brew install --cask swimat
 brew install --cask spotify
 brew install --cask imageoptim
 brew install --cask soundflower
@@ -31,7 +30,6 @@ brew install --cask visual-studio-code
 brew install --cask adobe-creative-cloud
 brew install --cask gyazo
 brew install --cask zoomus
-brew install --cask tandem
 brew install --cask discord
 brew install --cask notion
 brew install --cask figma

--- a/appstore.sh
+++ b/appstore.sh
@@ -13,15 +13,14 @@ EOS
 #
 echo " ---- Mac App Store apps -----"
 brew install mas
-mas install 409183694  # Keynote (6.6.2)
-mas install 425424353  # The Unarchiver (3.11.1)
-mas install 803453959  # Slack (2.4.1)
-mas install 409201541  # Pages (5.6.2)
-mas install 1024640650 # CotEditor (3.1.2)
-mas install 453164367  # SystemPal (5.2)
-mas install 539883307  # LINE (4.11.1)
-mas install 412529613  # Cinch (1.2.2)
-mas install 409203825  # Numbers (3.6.2)
-mas install 476533227  # Prepo (2.2.7)
+mas install 409183694  # Keynote
+mas install 425424353  # The Unarchiver
+mas install 803453959  # Slack
+mas install 409201541  # Pages
+mas install 1024640650 # CotEditor
+mas install 453164367  # SystemPal
+mas install 539883307  # LINE
+mas install 412529613  # Cinch
+mas install 409203825  # Numbers
 mas install 549083868  # Display Menu (2.2.3)
 echo " ------------ END ------------"


### PR DESCRIPTION
The system told me that swimat doesn't work on macOS 11.6