### PR TITLE
:sparkles: Add gh CLI instructions for AI agent non-interactive usage

### DIFF
--- a/github-copilot/gh-cli.instructions.md
+++ b/github-copilot/gh-cli.instructions.md
@@ -9,7 +9,7 @@ description: "Use when running gh CLI commands as an AI agent: avoid interactive
 ### 基本原則
 
 - `GH_PAGER=cat` を先頭に付けてページャーを無効化する
-- `gh pr` / `gh issue` などのサブコマンドでは `--json` フラグで構造化データとして受け取る（`gh api` は常に JSON を返すため不要）
+- `gh pr` / `gh issue` などのサブコマンドでは `--json` フラグで構造化データとして受け取る（`gh api` は多くの GitHub REST API エンドポイントで JSON を返すため通常は `--json` 不要だが、`Accept` ヘッダーや diff/patch 系エンドポイントでは JSON 以外が返ることもある）
 - `--jq` で必要なフィールドだけ抽出することで出力を小さく保つ
 - インタラクティブプロンプトが出ないよう、必要な引数はすべて明示的に指定する
 
@@ -19,11 +19,11 @@ description: "Use when running gh CLI commands as an AI agent: avoid interactive
 # タイムラインコメント（PR全体へのコメント）
 GH_PAGER=cat gh pr view <PR番号> --json comments --jq '.comments[] | {author: .author.login, body: .body}'
 
-# レビューコメント（インラインの行コメント）- --paginate で全件取得
-GH_PAGER=cat gh api repos/{owner}/{repo}/pulls/<PR番号>/comments --paginate
+# レビューコメント（インラインの行コメント）- --paginate で全件取得し --jq で絞り込む
+GH_PAGER=cat gh api repos/{owner}/{repo}/pulls/<PR番号>/comments --paginate --jq '.[] | {author: .user.login, body: .body, path: .path, line: .line}'
 
-# レビュー一覧（Approve / Request Changes など）- --paginate で全件取得
-GH_PAGER=cat gh api repos/{owner}/{repo}/pulls/<PR番号>/reviews --paginate
+# レビュー一覧（Approve / Request Changes など）- --paginate で全件取得し --jq で絞り込む
+GH_PAGER=cat gh api repos/{owner}/{repo}/pulls/<PR番号>/reviews --paginate --jq '.[] | {author: .user.login, state: .state, body: .body}'
 ```
 
 `{owner}/{repo}` は以下で取得できる（`-q` は `--jq` のエイリアス）:

--- a/github-copilot/gh-cli.instructions.md
+++ b/github-copilot/gh-cli.instructions.md
@@ -1,0 +1,33 @@
+---
+description: "Use when running gh CLI commands as an AI agent: avoid interactive mode, use --json and --jq for structured output"
+---
+
+## `gh` CLI をAIエージェントとして操作するときのルール
+
+インタラクティブモードは高確率で失敗するため、以下を必ず守ること。
+
+### 基本原則
+
+- `GH_PAGER=cat` を先頭に付けてページャーを無効化する
+- `gh pr` / `gh issue` などのサブコマンドでは `--json` フラグで構造化データとして受け取る（`gh api` は常に JSON を返すため不要）
+- `--jq` で必要なフィールドだけ抽出することで出力を小さく保つ
+- インタラクティブプロンプトが出ないよう、必要な引数はすべて明示的に指定する
+
+### PRコメントの取得
+
+```bash
+# タイムラインコメント（PR全体へのコメント）
+GH_PAGER=cat gh pr view <PR番号> --json comments --jq '.comments[] | {author: .author.login, body: .body}'
+
+# レビューコメント（インラインの行コメント）
+GH_PAGER=cat gh api repos/{owner}/{repo}/pulls/<PR番号>/comments
+
+# レビュー一覧（Approve / Request Changes など）
+GH_PAGER=cat gh api repos/{owner}/{repo}/pulls/<PR番号>/reviews
+```
+
+`{owner}/{repo}` は以下で取得できる:
+
+```bash
+gh repo view --json nameWithOwner -q .nameWithOwner
+```

--- a/github-copilot/gh-cli.instructions.md
+++ b/github-copilot/gh-cli.instructions.md
@@ -19,15 +19,15 @@ description: "Use when running gh CLI commands as an AI agent: avoid interactive
 # タイムラインコメント（PR全体へのコメント）
 GH_PAGER=cat gh pr view <PR番号> --json comments --jq '.comments[] | {author: .author.login, body: .body}'
 
-# レビューコメント（インラインの行コメント）
-GH_PAGER=cat gh api repos/{owner}/{repo}/pulls/<PR番号>/comments
+# レビューコメント（インラインの行コメント）- --paginate で全件取得
+GH_PAGER=cat gh api repos/{owner}/{repo}/pulls/<PR番号>/comments --paginate
 
-# レビュー一覧（Approve / Request Changes など）
-GH_PAGER=cat gh api repos/{owner}/{repo}/pulls/<PR番号>/reviews
+# レビュー一覧（Approve / Request Changes など）- --paginate で全件取得
+GH_PAGER=cat gh api repos/{owner}/{repo}/pulls/<PR番号>/reviews --paginate
 ```
 
-`{owner}/{repo}` は以下で取得できる:
+`{owner}/{repo}` は以下で取得できる（`-q` は `--jq` のエイリアス）:
 
 ```bash
-gh repo view --json nameWithOwner -q .nameWithOwner
+GH_PAGER=cat gh repo view --json nameWithOwner --jq .nameWithOwner
 ```

--- a/github-copilot/gh-cli.instructions.md
+++ b/github-copilot/gh-cli.instructions.md
@@ -9,8 +9,8 @@ description: "Use when running gh CLI commands as an AI agent: avoid interactive
 ### 基本原則
 
 - `GH_PAGER=cat` を先頭に付けてページャーを無効化する
-- `gh pr` / `gh issue` などのサブコマンドでは `--json` フラグで構造化データとして受け取る（`gh api` は多くの GitHub REST API エンドポイントで JSON を返すため通常は `--json` 不要だが、`Accept` ヘッダーや diff/patch 系エンドポイントでは JSON 以外が返ることもある）
-- `--jq` で必要なフィールドだけ抽出することで出力を小さく保つ
+- `gh pr view` / `gh pr list` / `gh issue view` など `--json` をサポートするコマンドは `--json` + `--jq` で必要なフィールドだけ取得する
+- `gh api` は `--json` 不要（REST エンドポイントは JSON を返す）；`--paginate` で全件取得し `--jq` で絞り込む
 - インタラクティブプロンプトが出ないよう、必要な引数はすべて明示的に指定する
 
 ### PRコメントの取得

--- a/github-copilot/global-workflow.instructions.md
+++ b/github-copilot/global-workflow.instructions.md
@@ -35,3 +35,5 @@ When the user asks you to implement something and create a pull request:
 ---
 
 When the user asks for code review, follow `review.instructions.md`.
+
+When running `gh` CLI commands, follow `gh-cli.instructions.md`.


### PR DESCRIPTION
## Summary

Add a new instruction file for running `gh` CLI commands as an AI agent, and update `global-workflow.instructions.md` to reference it.

## Background

When an AI agent runs `gh` CLI commands, interactive mode is frequently triggered, causing failures. Explicit rules are needed to ensure non-interactive, structured output.

## Implementation

- Added `github-copilot/gh-cli.instructions.md` with the following rules:
  - Prefix commands with `GH_PAGER=cat` to disable the pager
  - Use `--json` + `--jq` for `gh pr` / `gh issue` subcommands
  - Note that `gh api` always returns JSON and does not need `--json`
  - Always pass all required arguments explicitly to avoid interactive prompts
  - Example commands for fetching PR timeline comments, review comments, and reviews
- Updated `global-workflow.instructions.md` to reference `gh-cli.instructions.md`

## Notes

- `GH_PROMPT_DISABLED=1` was intentionally excluded as it is not a valid `gh` CLI environment variable
- The new file follows the same pattern as other instruction files (no `applyTo`, referenced from `global-workflow`)
